### PR TITLE
Remove --tmpfs from dev container invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: format test run build-image run-container
+
 format:
 	@gofmt -w *.go
 
@@ -7,17 +9,8 @@ test:
 run:
 	@go run jlink.go util.go maven_central.go adoptium.go
 
-build:
+build-image:
 	@docker build -t 'jlink.online:latest' .
 
-push: build docker-login
-	docker tag jlink.online $(DOCKER_REPO):latest
-	docker tag jlink.online $(DOCKER_REPO):$(VERSION)
-	docker push $(DOCKER_REPO):latest
-	docker push $(DOCKER_REPO):$(VERSION)
-
-docker-login:
-	@eval "eval $$\( aws ecr --region us-east-2 get-login --no-include-email \)"
-
-run-container: build
-	@docker run --rm -p 80:80 --tmpfs /tmp jlink.online:latest
+run-container: build-image
+	@docker run --rm -p 80:80 jlink.online:latest


### PR DESCRIPTION
The recent changes to the Dockerfile broke the dev container because the runtime cache fell back to `/tmp` which seems to be a non-executable filesystem. Removed `--tmpfs` and also removed some unnecessary targets.