### PR TITLE
Retain /legal directory on Linux and macOS platforms only

### DIFF
--- a/jlink.go
+++ b/jlink.go
@@ -436,8 +436,10 @@ func jlink(jdk, mavenCentral, runtime, endian, version, platform, filename strin
 	archive, dir := newTemporaryFile(filename)
 	defer os.RemoveAll(dir)
 
-	// TODO: archiver can't handle symlinks in this directory
-	_ = os.RemoveAll(filepath.FromSlash(output + "/legal"))
+	// Archiver can't handle the symlinks in /legal on windows
+	if LOCAL_PLATFORM == "windows" {
+		_ = os.RemoveAll(filepath.FromSlash(output + "/legal"))
+	}
 
 	if err := archiver.Archive([]string{output}, archive); err != nil {
 		return nil, err

--- a/jlink_test.go
+++ b/jlink_test.go
@@ -58,6 +58,11 @@ func assertRuntimeContents(t *testing.T, output, version, platform string) {
 		_, err := os.Stat(filepath.FromSlash(output + "/jdk-" + version + "/bin/java"))
 		assert.NoError(t, err)
 	}
+
+	if determineLocalPlatform() != "windows" {
+		_, err := os.Stat(filepath.FromSlash(output + "/jdk-" + version + "/legal"))
+		assert.NoError(t, err)
+	}
 }
 
 // Ensure no files are present from the wrong platform


### PR DESCRIPTION
Since the symlink issue is exclusive to Windows, I'm deleting the `/legal` directory only if the host platform is Windows. We don't deploy to Windows, so the directory should be present for all runtimes we generate.

Closes #20.